### PR TITLE
Auto-install MenuMeters, by default to current user's Library folder

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,5 +27,11 @@ class menumeters {
     ensure   => installed,
     source   => 'http://www.ragingmenace.com/software/download/MenuMeters.dmg',
     provider => 'appdmg',
+    before   => Exec['menumeters_user_library_install'],
+  }
+
+  exec { 'menumeters_user_library_install':
+    command  => '"/Applications/MenuMeters Installer.app/Contents/Resources/InstallTool" --installuser',
+    creates  => "/Users/${::boxen_user}/Library/PreferencePanes/MenuMeters.prefPane",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,26 @@
 # == Class: menumeters
 #
-# Install the menumeters package
+# Install menumeters, by default to the current user's Library folder.
 #
 # === Parameters
 #
-# None.
+# [*installer_source*]
+#   String of URL to MenuMeters.dmg.
+#
+#   default: http://www.ragingmenace.com/software/download/MenuMeters.dmg
+#
+# [*installer_tool*]
+#   String of full path to MenuMeters' install script.
+#
+#   default: /Applications/MenuMeters Installer.app/Contents/Resources/InstallTool
+#
+# [*installer_flag*]
+#   String of arguments to $installer_tool. Known values are
+#   --installuser and --installlibrary, which are mutually
+#   exclusive. Elevated privs are likely required for
+#   --installlibrary, which has not been tested.
+#
+#   default: --installuser
 #
 # === Variables
 #
@@ -17,21 +33,34 @@
 # === Authors
 #
 # Adam Crews <adam@puppetlabs.com>
+# David Warden <dfwarden@gmail.com>
 #
 # === Copyright
 #
 # Copyright 2013 Adam Crews, unless otherwise nodted.
 #
-class menumeters {
-  package { 'menumeters':
-    ensure   => installed,
-    source   => 'http://www.ragingmenace.com/software/download/MenuMeters.dmg',
-    provider => 'appdmg',
-    before   => Exec['menumeters_user_library_install'],
+class menumeters (
+  $installer_source = 'http://www.ragingmenace.com/software/download/MenuMeters.dmg',
+  $installer_tool = '/Applications/MenuMeters Installer.app/Contents/Resources/InstallTool',
+  $installer_flag = '--installuser',
+) {
+
+  $installer_creates = $installer_flag ? {
+    '--installuser' => "/Users/${::boxen_user}/Library/PreferencePanes/MenuMeters.prefPane",
+    '--installlibrary' => '/Library/PreferencePanes/MenuMeters.prefPane',
+    default => fail("Value for \$installer_tool must be --installuser or --installlibrary, not ${installer_tool}."),
   }
 
-  exec { 'menumeters_user_library_install':
-    command  => '"/Applications/MenuMeters Installer.app/Contents/Resources/InstallTool" --installuser',
-    creates  => "/Users/${::boxen_user}/Library/PreferencePanes/MenuMeters.prefPane",
+  package { 'menumeters':
+    ensure   => installed,
+    source   => $installer_source,
+    provider => 'appdmg',
+    before   => Exec['exec_menumeters_prefpane_install'],
   }
+
+  exec { 'exec_menumeters_prefpane_install':
+    command  => "\"${installer_tool}\" ${installer_flag}",
+    creates  => $installer_creates,
+  }
+
 }


### PR DESCRIPTION
I parameterized the menumeters class and made it, by default, install MenuMeters to the current user's Library folder if it is not already installed there. There's also an option to perform a system-wide install. I'm still a complete newbie to rspec and could not get the travis build to work, but both the user and system-wide install methods work on my Yosemite machine, for what that's worth.
